### PR TITLE
Product carousel - Tailwind cdn, Swiper JS, Mockshop and custom produ…

### DIFF
--- a/assets/product-carousel.js
+++ b/assets/product-carousel.js
@@ -1,0 +1,82 @@
+class ProductCarousel extends HTMLElement {
+    constructor() {
+        super();
+
+        this.fetchProductMethod = this.fetchMockProducts();
+
+        const swiper = new Swiper('.swiper-product-carousel', {  
+            init: false,
+            slidesPerView: 1.4,
+            spaceBetween: 20,
+            lazyPreloadPrevNext: 1,
+            pagination: {
+              el: '.swiper-pagination',
+              type: 'progressbar',
+            },
+            breakpoints: {
+                768: {
+                    lazyPreloadPrevNext: 2,
+                    slidesPerView: 3,
+                    spaceBetween: 24,
+                },
+                1024: {
+                    slidesPerView: 4,
+                    grabCursor: true,
+                    preventClicks: true,
+                },
+            },
+        });
+
+        swiper.on('afterInit', function() {
+            this.fetchProductMethod;
+        });
+
+        swiper.init();
+    }
+
+    fetchMockProducts() {
+        if (this.hasAttribute('mockshop-products')) {
+            fetch('https://mock.shop/api?query={products(first:%2020){edges%20{node%20{id%20title%20description%20featuredImage%20{id%20url}%20variants(first:%203){edges%20{node%20{price%20{amount%20currencyCode}}}}}}}}', {
+                method: 'GET', 
+                credentials: 'same-origin', 
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            })
+            .then((response) => response.json())
+            .then((response) => {
+                const fetchedProducts = response.data.products.edges;
+
+                for(let i = 0; i < fetchedProducts.length; i++) {
+                    const variants = fetchedProducts[i].node.variants.edges[0];
+
+                    const productBlock = 
+                        '<product-block class="swiper-slide mb-4 group">\n' +
+                            '<div class="media--hover-effect overflow-hidden">\n' +
+                                '<img class="transition-transform duration-500 group-hover:scale-[1.03]" src="'+ fetchedProducts[i].node.featuredImage.url +'" loading="lazy" width="600"/>\n' +
+                                '<div class="swiper-lazy-preloader"></div>\n' +
+                            '</div>\n' +
+                            '<div class="py-[1.7rem]">\n' +
+                                '<p class="text-xl text-black mt-4 mb-1 group-hover:underline group-hover:underline-offset-[0.3rem]">'+ fetchedProducts[i].node.title +'</p>\n' +
+                                '<product-price class="text-3xl font-bold text-black flex mt-[0.7rem]">\n' +
+                                    '<p>\n' + 
+                                        variants.node.price.currencyCode + ' ' +
+                                        variants.node.price.amount +
+                                    '</p>\n' +
+                                '</product-price>\n' +
+                            '</div>\n' +
+                        '</product-block>\n'
+                    ;
+
+                    this.querySelector('.swiper-wrapper').innerHTML += productBlock;
+                }
+            })
+            .catch((error) => {
+                console.error('Mockshop Error: ' + error);
+            });
+        }
+    }
+}
+
+customElements.define('product-carousel', ProductCarousel);

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -283,6 +283,30 @@
         document.documentElement.classList.add('shopify-design-mode');
       }
     </script>
+
+    <script defer="defer" src="https://cdn.tailwindcss.com"></script>
+
+    <style type="text/tailwindcss">
+      @layer utilities {
+        .swiper-product-carousel .swiper-pagination-bullet-active,
+        .swiper-product-carousel .swiper-pagination-progressbar .swiper-pagination-progressbar-fill {
+          background: #000000;
+        }
+
+        .swiper-product-carousel .price {
+          font-size: 1.875rem;
+          line-height: 2.25rem;
+          margin-top: 0!important;
+        }
+      }
+    </style>
+
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css"
+    />
+
+    <script defer="defer" src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
   </head>
 
   <body class="gradient{% if settings.animations_hover_elements != 'none' %} animate--hover-{{ settings.animations_hover_elements }}{% endif %}">

--- a/sections/product-carousel.liquid
+++ b/sections/product-carousel.liquid
@@ -1,0 +1,163 @@
+{% liquid
+  assign padding_top = section.settings.padding_top
+  assign padding_bottom = section.settings.padding_bottom
+  assign padding_top_mobile = section.settings.padding_top_mobile
+  assign padding_bottom_mobile = section.settings.padding_bottom_mobile
+  assign title = section.settings.title | default: null
+  assign product_types = section.settings.product_types
+  assign product_list = section.settings.product_list | default: null
+  assign pagination = section.settings.pagination
+%}
+
+{% if product_types == 'custom' %}
+  {{ 'component-card.css' | asset_url | stylesheet_tag }}
+{% endif %}
+
+<script src="{{ 'product-carousel.js' | asset_url }}" defer="defer" type="module"></script>
+
+<style>
+  #{{ section.id }}.section-padding {
+      padding-top: {{ padding_top_mobile }}px;
+      padding-bottom: {{ padding_bottom_mobile }}px;
+  }
+  @media (min-width: 768px) {
+      #{{ section.id }}.section-padding {
+          padding-top: {{ padding_top }}px;
+          padding-bottom: {{ padding_bottom }}px;
+      }
+  }
+</style>
+
+<product-carousel 
+  id="{{ section.id }}"
+  class="section-padding block"
+  {% if product_types == 'mockshop' %}
+    mockshop-products
+  {% endif %}
+>
+  <div class="grid grid-cols-12 px-8 md:px-[24px]">
+    <div class="col-span-full">
+      <h2 class="text-5xl">
+        {{ title }}
+      </h2>
+    </div>
+  </div>
+
+  <div class="swiper swiper-product-carousel pb-10 px-8 md:px-[24px]">
+    <div class="swiper-wrapper">
+      {% if product_types == 'custom' %}
+        {% for product in product_list %}
+          {% render 'card-product',
+            product_carousel: true,
+            card_product: product,
+            media_aspect_ratio: 'portrait',
+            extend_height: false,
+            classes: 'swiper-slide mb-4',
+            title_class: 'text-xl text-black mt-4 mb-1',
+            price_class: 'font-bold text-black flex mt-[0.7rem]'
+          %}
+        {% endfor %}
+      {% endif %}
+    </div>
+
+    {% if pagination %}
+      <div class="swiper-pagination relative mt-4"></div>
+    {% endif %}
+  </div>
+</product-carousel>
+
+{% schema %}
+  {
+      "name": "Product carousel",
+      "class": "product-carousel",
+      "settings": [
+          {
+              "type": "header",
+              "content": "General settings"
+          },
+          {
+              "type": "range",
+              "id": "padding_top",
+              "label": "Padding top",
+              "min": 0,
+              "max": 100,
+              "step": 1,
+              "unit": "px",
+              "default": 0
+          },
+          {
+              "type": "range",
+              "id": "padding_bottom",
+              "label": "Padding bottom",
+              "min": 0,
+              "max": 100,
+              "step": 1,
+              "unit": "px",
+              "default": 0
+          },
+          {
+              "type": "range",
+              "id": "padding_top_mobile",
+              "label": "Padding top (Mobile)",
+              "min": 0,
+              "max": 100,
+              "step": 1,
+              "unit": "px",
+              "default": 0
+          },
+          {
+              "type": "range",
+              "id": "padding_bottom_mobile",
+              "label": "Padding bottom (Mobile)",
+              "min": 0,
+              "max": 100,
+              "step": 1,
+              "unit": "px",
+              "default": 0
+          },
+          {
+              "type": "header",
+              "content": "Section settings"
+          },
+          {
+              "type": "text",
+              "id": "title",
+              "label": "Title"
+          },
+          {
+            "type": "select",
+            "id": "product_types",
+            "label": "Product types",
+            "info": "Select the type of products you would like to display in the slider.",
+            "options": [
+              {
+                "value": "custom",
+                "label": "Custom products"
+              },
+              {
+                "value": "mockshop",
+                "label": "Mockshop products"
+              }
+            ],
+            "default": "mockshop"
+          },
+          {
+            "type": "product_list",
+            "id": "product_list",
+            "label": "Products",
+            "info": "The products selected here, will appear if 'Custom products' is selected as the 'Product Types'."
+          },
+          {
+            "type": "checkbox",
+            "id": "pagination",
+            "label": "Enable slider pagination.",
+            "default": false
+          }
+      ],
+      "presets": [
+          {
+              "name": "Product carousel"
+          }
+      ]
+  }
+{% endschema %}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -40,7 +40,7 @@
       assign ratio = 1
     endif
   -%}
-  <div class="card-wrapper product-card-wrapper underline-links-hover">
+  <div class="card-wrapper product-card-wrapper underline-links-hover {{ classes }}">
     <div
       class="
         card card--{{ settings.card_style }}
@@ -60,28 +60,43 @@
         {%- if card_product.featured_media -%}
           <div class="card__media{% if image_shape and image_shape != 'default' %} shape--{{ image_shape }} color-{{ settings.card_color_scheme }} gradient{% endif %}">
             <div class="media media--transparent media--hover-effect">
-              {% comment %}theme-check-disable ImgLazyLoading{% endcomment %}
-              <img
-                srcset="
-                  {%- if card_product.featured_media.width >= 165 -%}{{ card_product.featured_media | image_url: width: 165 }} 165w,{%- endif -%}
-                  {%- if card_product.featured_media.width >= 360 -%}{{ card_product.featured_media | image_url: width: 360 }} 360w,{%- endif -%}
-                  {%- if card_product.featured_media.width >= 533 -%}{{ card_product.featured_media | image_url: width: 533 }} 533w,{%- endif -%}
-                  {%- if card_product.featured_media.width >= 720 -%}{{ card_product.featured_media | image_url: width: 720 }} 720w,{%- endif -%}
-                  {%- if card_product.featured_media.width >= 940 -%}{{ card_product.featured_media | image_url: width: 940 }} 940w,{%- endif -%}
-                  {%- if card_product.featured_media.width >= 1066 -%}{{ card_product.featured_media | image_url: width: 1066 }} 1066w,{%- endif -%}
-                  {{ card_product.featured_media | image_url }} {{ card_product.featured_media.width }}w
-                "
-                src="{{ card_product.featured_media | image_url: width: 533 }}"
-                sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 130 | divided_by: 4 }}px, (min-width: 990px) calc((100vw - 130px) / 4), (min-width: 750px) calc((100vw - 120px) / 3), calc((100vw - 35px) / 2)"
-                alt="{{ card_product.featured_media.alt | escape }}"
-                class="motion-reduce"
-                {% unless lazy_load == false %}
-                  loading="lazy"
-                {% endunless %}
-                width="{{ card_product.featured_media.width }}"
-                height="{{ card_product.featured_media.height }}"
-              >
-              {% comment %}theme-check-enable ImgLazyLoading{% endcomment %}
+              
+              {% if product_carousel %}
+                {% if section.index > 2 %}
+                  {%- assign loading = 'lazy' -%}
+                {% else %}
+                  {%- assign loading = 'eager' -%}
+                {% endif %}
+
+                {{ card_product.featured_media 
+                  | image_url: width: 1000 
+                  | image_tag: sizes: '(min-width:1440px) 1000px, (min-width:1024px) 600px, 320px',
+                  loading: loading
+                }}
+              {% else %}
+                {% comment %}theme-check-disable ImgLazyLoading{% endcomment %}
+                <img
+                  srcset="
+                    {%- if card_product.featured_media.width >= 165 -%}{{ card_product.featured_media | image_url: width: 165 }} 165w,{%- endif -%}
+                    {%- if card_product.featured_media.width >= 360 -%}{{ card_product.featured_media | image_url: width: 360 }} 360w,{%- endif -%}
+                    {%- if card_product.featured_media.width >= 533 -%}{{ card_product.featured_media | image_url: width: 533 }} 533w,{%- endif -%}
+                    {%- if card_product.featured_media.width >= 720 -%}{{ card_product.featured_media | image_url: width: 720 }} 720w,{%- endif -%}
+                    {%- if card_product.featured_media.width >= 940 -%}{{ card_product.featured_media | image_url: width: 940 }} 940w,{%- endif -%}
+                    {%- if card_product.featured_media.width >= 1066 -%}{{ card_product.featured_media | image_url: width: 1066 }} 1066w,{%- endif -%}
+                    {{ card_product.featured_media | image_url }} {{ card_product.featured_media.width }}w
+                  "
+                  src="{{ card_product.featured_media | image_url: width: 533 }}"
+                  sizes="(min-width: {{ settings.page_width }}px) {{ settings.page_width | minus: 130 | divided_by: 4 }}px, (min-width: 990px) calc((100vw - 130px) / 4), (min-width: 750px) calc((100vw - 120px) / 3), calc((100vw - 35px) / 2)"
+                  alt="{{ card_product.featured_media.alt | escape }}"
+                  class="motion-reduce"
+                  {% unless lazy_load == false %}
+                    loading="lazy"
+                  {% endunless %}
+                  width="{{ card_product.featured_media.width }}"
+                  height="{{ card_product.featured_media.height }}"
+                >
+                {% comment %}theme-check-enable ImgLazyLoading{% endcomment %}
+              {% endif %}
 
               {%- if card_product.media[1] != null and show_secondary_image -%}
                 <img
@@ -117,7 +132,7 @@
               <a
                 href="{{ card_product.url }}"
                 id="StandardCardNoMediaLink-{{ section_id }}-{{ card_product.id }}"
-                class="full-unstyled-link"
+                class="full-unstyled-link {{ title_class }}"
                 aria-labelledby="StandardCardNoMediaLink-{{ section_id }}-{{ card_product.id }} NoMediaStandardBadge-{{ section_id }}-{{ card_product.id }}"
               >
                 {{ card_product.title | escape }}
@@ -154,13 +169,13 @@
             <a
               href="{{ card_product.url }}"
               id="CardLink-{{ section_id }}-{{ card_product.id }}"
-              class="full-unstyled-link"
+              class="full-unstyled-link {{ title_class }}"
               aria-labelledby="CardLink-{{ section_id }}-{{ card_product.id }} Badge-{{ section_id }}-{{ card_product.id }}"
             >
               {{ card_product.title | escape }}
             </a>
           </h3>
-          <div class="card-information">
+          <div class="card-information {{ price_class }}">
             {%- if show_vendor -%}
               <span class="visually-hidden">{{ 'accessibility.vendor' | t }}</span>
               <div class="caption-with-letter-spacing light">{{ card_product.vendor }}</div>
@@ -505,7 +520,7 @@
                         </a>
                       </div>
                       <div class="quick-add-modal__content-info--bulk-details large-up-hide">
-                        <a href="{{ card_product.url }}" class="full-unstyled-link">
+                        <a href="{{ card_product.url }}" class="full-unstyled-link {{ title_class }}">
                           <h3>{{ card_product.title | escape }}</h3>
                         </a>
                         {% render 'price', product: card_product, price_class: '', show_compare_at_price: true %}
@@ -518,7 +533,7 @@
                     </div>
                     <div>
                       <div class="quick-add-modal__content-info--bulk-details small-hide medium-hide">
-                        <a href="{{ card_product.url }}" class="full-unstyled-link">
+                        <a href="{{ card_product.url }}" class="full-unstyled-link {{ title_class }}">
                           <h3 class="h2">
                             {{ card_product.title | escape }}
                           </h3>
@@ -605,7 +620,7 @@
               {{ 'onboarding.product_title' | t }}
             </a>
           </h3>
-          <div class="card-information">
+          <div class="card-information {{ price_class }}">
             {%- if show_vendor -%}
               <span class="visually-hidden">{{ 'accessibility.vendor' | t }}</span>
               <div class="caption-with-letter-spacing light">{{ 'products.product.vendor' | t }}</div>

--- a/templates/index.json
+++ b/templates/index.json
@@ -1,1 +1,66 @@
-{"sections":{"image_banner":{"type":"image-banner","blocks":{"heading":{"type":"heading","settings":{"heading":"Browse our latest products","heading_size":"h0"}},"button":{"type":"buttons","settings":{"button_label_1":"Shop all","button_link_1":"shopify:\/\/collections\/all","button_style_secondary_1":true,"button_label_2":"","button_link_2":"","button_style_secondary_2":false}}},"block_order":["heading","button"],"settings":{"image_overlay_opacity":40,"image_height":"large","desktop_content_position":"bottom-center","show_text_box":false,"desktop_content_alignment":"center","color_scheme":"scheme-3","image_behavior":"none","mobile_content_alignment":"center","stack_images_on_mobile":false,"show_text_below":false}},"featured_collection":{"type":"featured-collection","settings":{"title":"Featured products","heading_size":"h2","description":"","show_description":false,"description_style":"body","collection":"all","products_to_show":8,"columns_desktop":4,"full_width":false,"show_view_all":true,"view_all_style":"solid","enable_desktop_slider":false,"color_scheme":"scheme-1","image_ratio":"adapt","image_shape":"default","show_secondary_image":true,"show_vendor":false,"show_rating":false,"quick_add":"none","columns_mobile":"2","swipe_on_mobile":false,"padding_top":44,"padding_bottom":36}}},"order":["image_banner","featured_collection"]}
+{
+  "sections": {
+    "image_banner": {
+      "type": "image-banner",
+      "blocks": {
+        "heading": {
+          "type": "heading",
+          "settings": {
+            "heading": "Browse our latest products",
+            "heading_size": "h0"
+          }
+        },
+        "button": {
+          "type": "buttons",
+          "settings": {
+            "button_label_1": "Shop all",
+            "button_link_1": "shopify:\/\/collections\/all",
+            "button_style_secondary_1": true,
+            "button_label_2": "",
+            "button_link_2": "",
+            "button_style_secondary_2": false
+          }
+        }
+      },
+      "block_order": [
+        "heading",
+        "button"
+      ],
+      "settings": {
+        "image_overlay_opacity": 40,
+        "image_height": "large",
+        "desktop_content_position": "bottom-center",
+        "show_text_box": false,
+        "desktop_content_alignment": "center",
+        "color_scheme": "scheme-3",
+        "image_behavior": "none",
+        "mobile_content_alignment": "center",
+        "stack_images_on_mobile": false,
+        "show_text_below": false
+      }
+    },
+    "product_carousel_8MtRPj": {
+      "type": "product-carousel",
+      "settings": {
+        "padding_top": 25,
+        "padding_bottom": 25,
+        "padding_top_mobile": 35,
+        "padding_bottom_mobile": 35,
+        "title": "New arrivals",
+        "product_types": "mockshop",
+        "product_list": [
+          "fredo-jacket",
+          "lazar-jacket-in-black",
+          "lazar-leather-jacket",
+          "powell-jacket",
+          "lazar-jacket-in-denim"
+        ],
+        "pagination": true
+      }
+    }
+  },
+  "order": [
+    "image_banner",
+    "product_carousel_8MtRPj"
+  ]
+}


### PR DESCRIPTION
Contains a Product carousel section using test products from Mock.shop with the 'get 20 products' fetch option, as well as an optional selection in the customiser for normal products created in a shopify store. Also the Dawn theme's 'card-product' snippet is being used for the normal products selection/option when enabled.

Libraries/Tools:
-Tailwind CDN
-Swiper JS